### PR TITLE
Update Terraform Syntax and Ruby Function Version

### DIFF
--- a/api_gateway.tf
+++ b/api_gateway.tf
@@ -13,11 +13,8 @@ resource "aws_api_gateway_rest_api" "wcalink_gateway" {
 }
 # Certificate for the https endpoint of the API Gateway
 resource "aws_acm_certificate" "cert" {
-  # Trying to use a certificate defined in us-west-2 gives the following error:
-  # Error: Error creating API Gateway Domain Name: BadRequestException: Invalid certificate ARN: arn:aws:acm:us-west-2:285938427530:certificate/eee73fc7-776b-4b26-a51c-e612f546ac39. Certificate must be in 'us-east-1'.
-  # status code: 400, request id: 6e1e2fb3-3d83-4899-8658-9efb105bedf1
-  # This looks like the same issue discussed here: https://forums.aws.amazon.com/thread.jspa?messageID=770442.
-  provider          = "aws.us-east-1"
+  # API Gateway Certs need to live in us-east-1
+  provider          = aws.us-east-1
 
   domain_name       = "wca.link"
   validation_method = "DNS"
@@ -38,37 +35,37 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  provider = "aws.us-east-1" # The cert exists in us-east-1 (see comments above for aws_acm_certificate)
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  provider = aws.us-east-1 # The cert exists in us-east-1 (see comments above for aws_acm_certificate)
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }
 # Custom Domain Name for the API Gateway Endpoint
 resource "aws_api_gateway_domain_name" "wcalink_domain" {
-  certificate_arn = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
   domain_name     = "wca.link"
 }
 
 # This is the Alias record for the API Gateway Domain Name
 resource "aws_route53_record" "alias" {
-  name    = "${aws_api_gateway_domain_name.wcalink_domain.domain_name}"
+  name    = aws_api_gateway_domain_name.wcalink_domain.domain_name
   type    = "A"
-  zone_id = "${aws_route53_zone.zone.id}"
+  zone_id = aws_route53_zone.zone.id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.wcalink_domain.cloudfront_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.wcalink_domain.cloudfront_zone_id}"
+    name                   = aws_api_gateway_domain_name.wcalink_domain.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.wcalink_domain.cloudfront_zone_id
   }
 }
 # Map / to the custom domain
 resource "aws_api_gateway_base_path_mapping" "prod" {
-  api_id      = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  stage_name  = "${aws_api_gateway_deployment.wcalink_prod_deployment.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.wcalink_domain.domain_name}"
+  api_id      = aws_api_gateway_rest_api.wcalink_gateway.id
+  stage_name  = aws_api_gateway_deployment.wcalink_prod_deployment.stage_name
+  domain_name = aws_api_gateway_domain_name.wcalink_domain.domain_name
 }
 
 # Output URL for Testing
 output "base_url" {
-  value = "${aws_api_gateway_deployment.wcalink_prod_deployment.invoke_url}"
+  value = aws_api_gateway_deployment.wcalink_prod_deployment.invoke_url
 }
 

--- a/backend.tf
+++ b/backend.tf
@@ -7,11 +7,6 @@
 resource "aws_s3_bucket" "terraform-state-storage-s3" {
   bucket = "wca-terraform-state"
 
-  versioning {
-    # enable with caution, makes deleting S3 buckets tricky
-    enabled = false
-  }
-
   lifecycle {
     prevent_destroy = true
   }
@@ -21,8 +16,8 @@ resource "aws_s3_bucket" "terraform-state-storage-s3" {
 resource "aws_dynamodb_table" "dynamodb-terraform-state-lock" {
   name = "wca-terraform-state-lock-dynamo"
   hash_key = "LockID"
-  read_capacity = 20
-  write_capacity = 20
+  read_capacity = 5
+  write_capacity = 5
 
   attribute {
     name = "LockID"

--- a/lambda.tf
+++ b/lambda.tf
@@ -23,72 +23,70 @@ EOF
 resource "aws_lambda_function" "wcalink_lambda" {
   filename      = "build/lambda_function_payload.zip"
   function_name = "wcalink_prod"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "lambda_function.lambda_handler"
 
   # The filebase64sha256() function is available in Terraform 0.11.12 and later
-  # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
-  # source_code_hash = "${base64sha256(file("build/lambda_function_payload.zip"))}"
-  source_code_hash = "${filebase64sha256("build/lambda_function_payload.zip")}"
+  source_code_hash = filebase64sha256("build/lambda_function_payload.zip")
 
-  runtime = "ruby2.7"
+  runtime = "ruby3.2"
 }
 # The Proxy Ressource Makes it possible for a whole path to be handled by
 # the same lambda
 resource "aws_api_gateway_resource" "proxy" {
-  rest_api_id = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  parent_id   = "${aws_api_gateway_rest_api.wcalink_gateway.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.wcalink_gateway.id
+  parent_id   = aws_api_gateway_rest_api.wcalink_gateway.root_resource_id
   path_part   = "{proxy+}"
 }
 
 resource "aws_api_gateway_method" "proxy" {
-  rest_api_id   = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  resource_id   = "${aws_api_gateway_resource.proxy.id}"
+  rest_api_id   = aws_api_gateway_rest_api.wcalink_gateway.id
+  resource_id   = aws_api_gateway_resource.proxy.id
   http_method   = "ANY"
   authorization = "NONE"
 }
 # Additional Route for the root
 resource "aws_api_gateway_method" "proxy_root" {
-  rest_api_id   = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  resource_id   = "${aws_api_gateway_rest_api.wcalink_gateway.root_resource_id}"
+  rest_api_id   = aws_api_gateway_rest_api.wcalink_gateway.id
+  resource_id   = aws_api_gateway_rest_api.wcalink_gateway.root_resource_id
   http_method   = "ANY"
   authorization = "NONE"
 }
 # Plugging the Lambda behind the ressources
 resource "aws_api_gateway_integration" "lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  resource_id = "${aws_api_gateway_method.proxy.resource_id}"
-  http_method = "${aws_api_gateway_method.proxy.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.wcalink_gateway.id
+  resource_id = aws_api_gateway_method.proxy.resource_id
+  http_method = aws_api_gateway_method.proxy.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.wcalink_lambda.invoke_arn}"
+  uri                     = aws_lambda_function.wcalink_lambda.invoke_arn
 }
 
 resource "aws_api_gateway_integration" "lambda_root" {
-  rest_api_id = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
-  resource_id = "${aws_api_gateway_method.proxy_root.resource_id}"
-  http_method = "${aws_api_gateway_method.proxy_root.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.wcalink_gateway.id
+  resource_id = aws_api_gateway_method.proxy_root.resource_id
+  http_method = aws_api_gateway_method.proxy_root.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.wcalink_lambda.invoke_arn}"
+  uri                     = aws_lambda_function.wcalink_lambda.invoke_arn
 }
 # Deploying the API Gateway
 resource "aws_api_gateway_deployment" "wcalink_prod_deployment" {
   depends_on = [
-    "aws_api_gateway_integration.lambda",
-    "aws_api_gateway_integration.lambda_root",
+    aws_api_gateway_integration.lambda,
+    aws_api_gateway_integration.lambda_root,
   ]
 
-  rest_api_id = "${aws_api_gateway_rest_api.wcalink_gateway.id}"
+  rest_api_id = aws_api_gateway_rest_api.wcalink_gateway.id
   stage_name  = "prod"
 }
 # Give the API Gateway Permission to invoke the Lambda
 resource "aws_lambda_permission" "apigw" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.wcalink_lambda.function_name}"
+  function_name = aws_lambda_function.wcalink_lambda.function_name
   principal     = "apigateway.amazonaws.com"
 
   # The "/*/*" portion grants access from any method on any resource


### PR DESCRIPTION
This PR:
- Updates the Terraform Syntax to work with Version 14 (no more deprecation warnings come up when I run `terraform plan`)
- Updates the Lambda Function Version to 3.2 because 2.7 is EOL.
- Changes the Read Capacity from DynamoDB from 20 to 5 because 20 is waaaaaay too much and costs us like 20 bucks a year unnecessarily. This should better yet just be a on demand DynamoDB Table